### PR TITLE
Refactor: introduce modular blockchain service

### DIFF
--- a/code/services/blockchain/cache.js
+++ b/code/services/blockchain/cache.js
@@ -1,0 +1,37 @@
+import { BLOCKCHAIN_CONFIG } from '../../constants/app';
+
+const cache = new Map();
+
+export function getCacheKey(method, ...args) {
+    return `${method}_${JSON.stringify(args)}`;
+}
+
+export function getFromCache(key) {
+    const cached = cache.get(key);
+    if (cached && Date.now() - cached.timestamp < BLOCKCHAIN_CONFIG.CACHE_TTL) {
+        return cached.data;
+    }
+
+    cache.delete(key);
+    return null;
+}
+
+export function setCache(key, data) {
+    cache.set(key, { data, timestamp: Date.now() });
+}
+
+export function invalidateUserCache(walletAddress) {
+    const keysToDelete = [];
+
+    for (const key of cache.keys()) {
+        if (key.includes(walletAddress)) {
+            keysToDelete.push(key);
+        }
+    }
+
+    keysToDelete.forEach(key => cache.delete(key));
+}
+
+export function clearCache() {
+    cache.clear();
+}

--- a/code/services/blockchain/certificates.js
+++ b/code/services/blockchain/certificates.js
@@ -1,0 +1,187 @@
+import { ethers } from 'ethers';
+import { addClaim } from '../ethereum/scripts/claims/add-claim';
+import { CLAIM_TOPICS_OBJ } from '../ethereum/scripts/claims/claimTopics';
+import hash from '../ethereum/scripts/utils/encryption/hash';
+import { encrypt } from '../ethereum/scripts/utils/encryption/aes-256';
+import { BlockchainError } from '../errors/ErrorHandler';
+import { formatCertificateClaim } from './claimFormat';
+import { getClaimIssuerContract, getTrustedIssuerRegistry, getWalletFromPrivateKey } from './contracts';
+import { getUserClaims, getUserIdentity } from './identities';
+import { findInstitutionByWallet, isTrustedIssuerForTopic } from './institutions';
+import { invalidateUserCache } from './cache';
+
+export async function issueCertificate({
+    issuerWallet,
+    receiverWalletAddress,
+    registrationCode,
+    courseID,
+    grade,
+    certificateReference,
+    password,
+}) {
+    try {
+        const institution = getIssuingInstitution(issuerWallet);
+
+        if (!certificateReference) {
+            throw new BlockchainError('Certificate reference is required');
+        }
+
+        const identity = await getUserIdentity(receiverWalletAddress);
+
+        if (!identity) {
+            throw new BlockchainError('Student identity not found');
+        }
+
+        const claimIssuerWallet = getWalletFromPrivateKey(institution.wallet.privateKey);
+        await assertIssuerCanWriteCertificate(identity, institution, claimIssuerWallet.address);
+
+        const operations = buildCertificateClaims({
+            institution,
+            registrationCode,
+            courseID,
+            grade,
+            certificateReference,
+            password,
+        });
+
+        const trustedIR = getTrustedIssuerRegistry();
+        const claimIssuerContract = getClaimIssuerContract(institution);
+
+        for (const operation of operations) {
+            await addClaim(
+                trustedIR,
+                identity,
+                claimIssuerContract,
+                claimIssuerWallet,
+                operation.claimTopic,
+                operation.claimData,
+                1,
+                operation.uri || '',
+                operation.password
+            );
+        }
+
+        invalidateUserCache(receiverWalletAddress);
+        return true;
+    } catch (error) {
+        if (error instanceof BlockchainError) throw error;
+        throw new BlockchainError(`Failed to issue certificate: ${error.message}`);
+    }
+}
+
+export async function revokeCertificate({ issuerWallet, receiverWalletAddress, claimId = null }) {
+    try {
+        const institution = getIssuingInstitution(issuerWallet);
+        const identity = await getUserIdentity(receiverWalletAddress);
+
+        if (!identity) {
+            throw new BlockchainError('Student identity not found');
+        }
+
+        const certificates = await getUserClaims(receiverWalletAddress, CLAIM_TOPICS_OBJ.CERTIFICATE);
+        const targetClaim = findRevocationTarget(certificates, institution, claimId);
+
+        if (!targetClaim) {
+            throw new BlockchainError('Certificate claim not found for this institution');
+        }
+
+        const claimIssuerWallet = getWalletFromPrivateKey(institution.wallet.privateKey);
+        const tx = await identity.connect(claimIssuerWallet).removeClaim(targetClaim.id);
+        await tx.wait();
+
+        invalidateUserCache(receiverWalletAddress);
+        return true;
+    } catch (error) {
+        if (error instanceof BlockchainError) throw error;
+        throw new BlockchainError(`Failed to revoke certificate: ${error.message}`);
+    }
+}
+
+export async function getCertificatesForWallet(walletAddress) {
+    try {
+        const claims = await getUserClaims(walletAddress, CLAIM_TOPICS_OBJ.CERTIFICATE);
+        return claims.map((claim, index) => formatCertificateClaim(claim, index));
+    } catch (error) {
+        throw new BlockchainError(`Failed to get certificates: ${error.message}`);
+    }
+}
+
+function getIssuingInstitution(issuerWallet) {
+    const institution = findInstitutionByWallet(issuerWallet?.address);
+
+    if (!institution?.wallet?.privateKey) {
+        throw new BlockchainError('Connected wallet is not an accredited institution');
+    }
+
+    if (!institution.address || !institution.abi?.length) {
+        throw new BlockchainError(
+            'Institution ClaimIssuer is not deployed in the current app config. Run ./install.sh --local, then reload the app.'
+        );
+    }
+
+    return institution;
+}
+
+async function assertIssuerCanWriteCertificate(identity, institution, claimSignerAddress) {
+    const claimKey = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(['address'], [claimSignerAddress])
+    );
+    const issuerAuthorizedOnIdentity = await identity.keyHasPurpose(claimKey, 3);
+
+    if (!issuerAuthorizedOnIdentity) {
+        throw new BlockchainError(
+            'Student identity has not authorized this institution yet. Log in as the student and activate the identity from Home with the student private key.'
+        );
+    }
+
+    const canIssueCertificates = await isTrustedIssuerForTopic(
+        institution.address,
+        CLAIM_TOPICS_OBJ.CERTIFICATE
+    );
+    if (!canIssueCertificates) {
+        throw new BlockchainError('Institution is not accredited to issue certificate claims');
+    }
+}
+
+function buildCertificateClaims({
+    institution,
+    registrationCode,
+    courseID,
+    grade,
+    certificateReference,
+    password,
+}) {
+    return [
+        {
+            claimTopic: CLAIM_TOPICS_OBJ.INSTITUTION,
+            claimData: JSON.stringify({
+                institutionID: institution.institutionID.toString(),
+                courseID,
+            }),
+        },
+        {
+            claimTopic: CLAIM_TOPICS_OBJ.STUDENT,
+            claimData: JSON.stringify({ grade }),
+        },
+        {
+            claimTopic: CLAIM_TOPICS_OBJ.CERTIFICATE,
+            claimData: JSON.stringify({
+                registrationCode,
+                courseID,
+                grade,
+                certificateDigest: hash(certificateReference),
+                encryptedCertificateReference: password ? encrypt(certificateReference, password) : '',
+            }),
+            uri: certificateReference,
+            password,
+        },
+    ];
+}
+
+function findRevocationTarget(certificates, institution, claimId) {
+    if (claimId !== null) {
+        return certificates.find(claim => claim.id === claimId);
+    }
+
+    return certificates.find(claim => claim.issuer?.toLowerCase() === institution.address.toLowerCase());
+}

--- a/code/services/blockchain/claimFormat.js
+++ b/code/services/blockchain/claimFormat.js
@@ -1,0 +1,27 @@
+import { ethers } from 'ethers';
+
+export function parseClaimData(data) {
+    try {
+        const text = ethers.toUtf8String(data);
+        return JSON.parse(text);
+    } catch {
+        return {};
+    }
+}
+
+export function formatCertificateClaim(claim, index) {
+    const data = parseClaimData(claim.data);
+
+    return {
+        id: claim.id || claim.claimId || `${claim.issuer}-${index}`,
+        title: data.courseID ? `Course ${data.courseID}` : `Certificate #${index + 1}`,
+        registrationCode: data.registrationCode,
+        grade: data.grade,
+        issuer: claim.issuer,
+        digest: data.certificateDigest || claim.uri,
+        uri: claim.uri,
+        encryptedReference: data.encryptedCertificateReference || '',
+        rawData: data,
+        rawClaim: claim,
+    };
+}

--- a/code/services/blockchain/contracts.js
+++ b/code/services/blockchain/contracts.js
@@ -1,0 +1,39 @@
+import { getContractAt, getWallet, jsonRpcProvider } from '../ethereum/scripts/utils/ethers';
+import { useRpcProvider } from '../ethereum/scripts/utils/useRpcProvider';
+import config from '../../config.json';
+
+let signer = null;
+
+export function getSigner() {
+    if (!signer) {
+        signer = useRpcProvider(config.rpc, config.deployer.privateKey);
+    }
+
+    return signer;
+}
+
+export function getProvider() {
+    return jsonRpcProvider(config.rpc);
+}
+
+export function getIdentityFactory() {
+    return getContractAt(config.identityFactory.address, config.identityFactory.abi, getSigner());
+}
+
+export function getTrustedIssuerRegistry() {
+    return getContractAt(
+        config.trex.trustedIssuersRegistry.address,
+        config.trex.trustedIssuersRegistry.abi,
+        getSigner()
+    );
+}
+
+export function getClaimIssuerContract(institution) {
+    return getContractAt(institution.address, institution.abi, getSigner());
+}
+
+export function getWalletFromPrivateKey(privateKey) {
+    return getWallet(privateKey, getProvider());
+}
+
+export { getContractAt };

--- a/code/services/blockchain/identities.js
+++ b/code/services/blockchain/identities.js
@@ -1,0 +1,141 @@
+import { ethers } from 'ethers';
+import { getIdentity } from '../ethereum/scripts/identities/getIdentity';
+import { deployIdentity } from '../ethereum/scripts/identities/deploy-identity';
+import { addKeyToIdentity } from '../ethereum/scripts/claimIssuer/addKeyToIdentity';
+import { getClaimsByTopic } from '../ethereum/scripts/claims/getClaimsByTopic';
+import { CLAIM_TOPICS_OBJ } from '../ethereum/scripts/claims/claimTopics';
+import { BLOCKCHAIN_CONFIG } from '../../constants/app';
+import { BlockchainError, retryOperation } from '../errors/ErrorHandler';
+import { getCacheKey, getFromCache, invalidateUserCache, setCache } from './cache';
+import { getIdentityFactory, getSigner, getWalletFromPrivateKey } from './contracts';
+import { getClaimSignerAddress, isTrustedIssuerForTopic } from './institutions';
+import config from '../../config.json';
+
+export async function getUserIdentity(walletAddress) {
+    const cacheKey = getCacheKey('getUserIdentity', walletAddress);
+    const cached = getFromCache(cacheKey);
+
+    if (cached) {
+        return cached;
+    }
+
+    try {
+        const identity = await retryOperation(
+            async () => await getIdentity(walletAddress, getIdentityFactory(), getSigner()),
+            BLOCKCHAIN_CONFIG.MAX_RETRIES,
+            BLOCKCHAIN_CONFIG.RETRY_DELAY
+        );
+
+        if (identity) {
+            setCache(cacheKey, identity);
+        }
+
+        return identity;
+    } catch (error) {
+        throw new BlockchainError(`Failed to get identity for ${walletAddress}: ${error.message}`);
+    }
+}
+
+export async function getUserClaims(walletAddress, claimTopic = null) {
+    const cacheKey = getCacheKey('getUserClaims', walletAddress, claimTopic);
+    const cached = getFromCache(cacheKey);
+
+    if (cached) {
+        return cached;
+    }
+
+    try {
+        const identity = await getUserIdentity(walletAddress);
+
+        if (!identity) {
+            throw new BlockchainError('Identity not found');
+        }
+
+        const claims = await retryOperation(
+            async () => {
+                if (claimTopic) {
+                    return await getClaimsByTopic(identity, claimTopic);
+                }
+
+                const [certificates, institutions, students] = await Promise.all([
+                    getClaimsByTopic(identity, CLAIM_TOPICS_OBJ.CERTIFICATE),
+                    getClaimsByTopic(identity, CLAIM_TOPICS_OBJ.INSTITUTION),
+                    getClaimsByTopic(identity, CLAIM_TOPICS_OBJ.STUDENT),
+                ]);
+
+                return { certificates, institutions, students };
+            },
+            BLOCKCHAIN_CONFIG.MAX_RETRIES,
+            BLOCKCHAIN_CONFIG.RETRY_DELAY
+        );
+
+        setCache(cacheKey, claims);
+        return claims;
+    } catch (error) {
+        throw new BlockchainError(`Failed to get claims: ${error.message}`);
+    }
+}
+
+export async function createIdentityForWallet(walletAddress) {
+    try {
+        if (!walletAddress) {
+            throw new BlockchainError('Wallet address is required');
+        }
+
+        const salt = `digo-${walletAddress.toLowerCase()}`;
+        const identity = await deployIdentity(getIdentityFactory(), walletAddress, salt, getSigner());
+
+        invalidateUserCache(walletAddress);
+        return identity;
+    } catch (error) {
+        if (error instanceof BlockchainError) throw error;
+        throw new BlockchainError(`Failed to create identity: ${error.message}`);
+    }
+}
+
+export async function authorizeAccreditedIssuersForWallet(wallet) {
+    try {
+        const { address, privateKey } = wallet ?? {};
+
+        if (!address || !privateKey) {
+            throw new BlockchainError('Wallet address and private key are required');
+        }
+
+        const identityWallet = getWalletFromPrivateKey(privateKey);
+        const identity = await createIdentityForWallet(address);
+        const results = [];
+
+        for (const institution of config.institutions || []) {
+            const issuerSignerAddress = getClaimSignerAddress(institution);
+            if (!issuerSignerAddress || !institution.address) continue;
+
+            const isTrusted = await isTrustedIssuerForTopic(
+                institution.address,
+                CLAIM_TOPICS_OBJ.CERTIFICATE
+            );
+            if (!isTrusted) {
+                results.push({ institutionID: institution.institutionID, skipped: true, reason: 'not trusted' });
+                continue;
+            }
+
+            const claimKey = ethers.keccak256(
+                ethers.AbiCoder.defaultAbiCoder().encode(['address'], [issuerSignerAddress])
+            );
+            const alreadyAuthorized = await identity.keyHasPurpose(claimKey, 3);
+
+            if (alreadyAuthorized) {
+                results.push({ institutionID: institution.institutionID, skipped: true });
+                continue;
+            }
+
+            const result = await addKeyToIdentity(identity, identityWallet, { address: issuerSignerAddress }, 3, 1);
+            results.push({ institutionID: institution.institutionID, result });
+        }
+
+        invalidateUserCache(address);
+        return results;
+    } catch (error) {
+        if (error instanceof BlockchainError) throw error;
+        throw new BlockchainError(`Failed to authorize issuers: ${error.message}`);
+    }
+}

--- a/code/services/blockchain/index.js
+++ b/code/services/blockchain/index.js
@@ -1,0 +1,22 @@
+export { clearCache, invalidateUserCache } from './cache';
+
+export {
+    getCertificatesForWallet,
+    issueCertificate,
+    revokeCertificate,
+} from './certificates';
+
+export {
+    authorizeAccreditedIssuersForWallet,
+    createIdentityForWallet,
+    getUserClaims,
+    getUserIdentity,
+} from './identities';
+
+export {
+    findInstitutionByIssuerAddress,
+    findInstitutionByWallet,
+    isTrustedIssuerForTopic,
+} from './institutions';
+
+export { validateCertificate } from './validation';

--- a/code/services/blockchain/institutions.js
+++ b/code/services/blockchain/institutions.js
@@ -1,0 +1,31 @@
+import { ethers } from 'ethers';
+import { getTrustedIssuerRegistry } from './contracts';
+import config from '../../config.json';
+
+export function findInstitutionByWallet(walletAddress) {
+    const normalizedAddress = walletAddress?.toLowerCase();
+    if (!normalizedAddress) return null;
+
+    return config.institutions?.find(
+        institution => institution.wallet?.address?.toLowerCase() === normalizedAddress
+    );
+}
+
+export function findInstitutionByIssuerAddress(issuerAddress) {
+    const normalizedAddress = issuerAddress?.toLowerCase();
+    if (!normalizedAddress) return null;
+
+    return config.institutions?.find(institution => institution.address?.toLowerCase() === normalizedAddress);
+}
+
+export function getClaimSignerAddress(institution) {
+    return institution?.wallet?.address || null;
+}
+
+export async function isTrustedIssuerForTopic(issuerAddress, claimTopic) {
+    if (!issuerAddress || !claimTopic) return false;
+
+    const trustedIR = getTrustedIssuerRegistry();
+    const topic = ethers.id(claimTopic);
+    return await trustedIR.hasClaimTopic(issuerAddress, topic);
+}

--- a/code/services/blockchain/validation.js
+++ b/code/services/blockchain/validation.js
@@ -1,0 +1,117 @@
+import { CLAIM_TOPICS_OBJ } from '../ethereum/scripts/claims/claimTopics';
+import hash from '../ethereum/scripts/utils/encryption/hash';
+import { BlockchainError } from '../errors/ErrorHandler';
+import { parseClaimData, formatCertificateClaim } from './claimFormat';
+import { getContractAt, getSigner } from './contracts';
+import { getUserClaims, getUserIdentity } from './identities';
+import { findInstitutionByIssuerAddress, isTrustedIssuerForTopic } from './institutions';
+
+const CLAIM_ISSUER_VALIDATION_ABI = [
+    'function isClaimValid(address identity, uint256 claimTopic, bytes sig, bytes data) view returns (bool)',
+];
+
+const failedChecks = {
+    digestMatch: false,
+    issuerTrusted: false,
+    signatureValid: false,
+};
+
+export async function validateCertificate(userAddress, certificateData) {
+    try {
+        const claims = await getUserClaims(userAddress, CLAIM_TOPICS_OBJ.CERTIFICATE);
+
+        if (!claims || claims.length === 0) {
+            return invalidResult('No certificates found for this address');
+        }
+
+        const certificateReference = getCertificateReference(certificateData);
+        if (!certificateReference) {
+            return invalidResult('No certificate reference provided');
+        }
+
+        const matchedClaim = findMatchingClaim(claims, certificateReference);
+        if (!matchedClaim) {
+            return {
+                ...invalidResult('Certificate digest does not match any on-chain claim'),
+                claims,
+            };
+        }
+
+        const identity = await getUserIdentity(userAddress);
+        const identityAddress = await identity.getAddress();
+        const institution = findInstitutionByIssuerAddress(matchedClaim.issuer);
+        const issuerTrusted = await isTrustedIssuerForTopic(matchedClaim.issuer, CLAIM_TOPICS_OBJ.CERTIFICATE);
+        const signatureValid = await validateClaimSignature(identityAddress, matchedClaim, institution);
+        const isValid = issuerTrusted && signatureValid;
+
+        return {
+            isValid,
+            reason: isValid ? null : 'Certificate claim exists, but issuer trust or signature validation failed',
+            checks: {
+                digestMatch: true,
+                issuerTrusted,
+                signatureValid,
+            },
+            issuer: formatIssuer(institution, matchedClaim.issuer),
+            claim: formatCertificateClaim(matchedClaim, 0),
+            claims,
+        };
+    } catch (error) {
+        throw new BlockchainError(`Certificate validation failed: ${error.message}`);
+    }
+}
+
+function invalidResult(reason) {
+    return {
+        isValid: false,
+        reason,
+        checks: { ...failedChecks },
+    };
+}
+
+function getCertificateReference(certificateData) {
+    if (typeof certificateData === 'string') {
+        return certificateData;
+    }
+
+    return certificateData?.content || certificateData?.certificateLink || certificateData?.uri;
+}
+
+function findMatchingClaim(claims, certificateReference) {
+    const targetHash = hash(certificateReference);
+
+    return claims.find(claim => {
+        const data = parseClaimData(claim.data);
+        return claim.uri === targetHash || data.certificateDigest === targetHash;
+    });
+}
+
+async function validateClaimSignature(identityAddress, claim, institution) {
+    try {
+        const claimIssuerContract = getContractAt(
+            claim.issuer,
+            institution?.abi || CLAIM_ISSUER_VALIDATION_ABI,
+            getSigner()
+        );
+
+        return await claimIssuerContract.isClaimValid(
+            identityAddress,
+            claim.topic,
+            claim.signature,
+            claim.data
+        );
+    } catch {
+        return false;
+    }
+}
+
+function formatIssuer(institution, issuerAddress) {
+    if (!institution) {
+        return { address: issuerAddress };
+    }
+
+    return {
+        institutionID: institution.institutionID,
+        address: institution.address,
+    };
+}

--- a/code/services/errors/ErrorHandler.js
+++ b/code/services/errors/ErrorHandler.js
@@ -1,0 +1,57 @@
+class ErrorHandler {
+    static logError(error, context = '') {
+        const prefix = context ? `[${context}] ` : '';
+        console.error(`${prefix}${error.message || error}`);
+    }
+
+    static processError(error, context = '') {
+        this.logError(error, context);
+
+        const message = error?.message || 'An unexpected error occurred.';
+        const normalizedMessage = message.toLowerCase();
+        let userMessage = message;
+
+        if (normalizedMessage.includes('user rejected')) {
+            userMessage = 'Transaction was cancelled by user.';
+        } else if (normalizedMessage.includes('insufficient funds')) {
+            userMessage = 'Insufficient funds to complete the transaction.';
+        } else if (normalizedMessage.includes('network')) {
+            userMessage = 'Network error. Please check your connection and try again.';
+        } else if (normalizedMessage.includes('nonce')) {
+            userMessage = 'Transaction nonce error. Please try again.';
+        } else if (normalizedMessage.includes('gas')) {
+            userMessage = 'Gas estimation failed. Please try again.';
+        }
+
+        return { userMessage, originalError: error };
+    }
+}
+
+export class BlockchainError extends Error {
+    constructor(message, code = null) {
+        super(message);
+        this.name = 'BlockchainError';
+        this.code = code;
+    }
+}
+
+export async function retryOperation(operation, maxRetries = 3, delay = 1000) {
+    let lastError;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+            return await operation();
+        } catch (error) {
+            lastError = error;
+            ErrorHandler.logError(error, `Attempt ${attempt}/${maxRetries}`);
+
+            if (attempt < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, delay * attempt));
+            }
+        }
+    }
+
+    throw lastError;
+}
+
+export default ErrorHandler;


### PR DESCRIPTION
## 📖 Summary

Refactors the mobile blockchain integration into focused service modules while preserving the existing certificate and identity behavior.

## 🤔 What has been done?

- Split blockchain logic into focused modules for cache, certificates, identities, institutions, and validation.
- Named exports from `@/services/blockchain`.
- Pruned unused error-handling boilerplate.
- Kept wallet contracts explicit: address-only calls receive address strings, wallet-object calls validate their required fields.

<!-- Explain any unchecked item. -->

## Evidence

- [x] `npm run test:blockchain`
- [x] `npx expo export --platform ios`
- [ ] Manual QA completed

## Review notes

**Depends on:** #9 

**Out of scope:**
- Authentication/session UX changes
- Reown AppKit migration
- Certificate replacement confirmation behavior

## Checklist

- [x] The PR has one clear responsibility
- [x] No secrets, private keys, or local endpoints are committed
- [x] Documentation reflects user-facing or setup changes
- [x] Dead code and obsolete dependencies were not introduced