### PR TITLE
Feat: confirm certificate claim replacement

### DIFF
--- a/code/hooks/useCertificateEmission.js
+++ b/code/hooks/useCertificateEmission.js
@@ -80,6 +80,19 @@ const validateForm = (form, fileInfo) => {
     }
 };
 
+const confirmCertificateReplacement = () =>
+    new Promise(resolve => {
+        Alert.alert(
+            'Certificate Already Exists',
+            'This institution already issued a certificate for this student. Replace the existing certificate?',
+            [
+                { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+                { text: 'Replace', style: 'destructive', onPress: () => resolve(true) },
+            ],
+            { cancelable: true, onDismiss: () => resolve(false) }
+        );
+    });
+
 export const useCertificateEmission = () => {
     const [state, dispatch] = useReducer(emissionReducer, initialState);
 
@@ -111,7 +124,21 @@ export const useCertificateEmission = () => {
                 password: state.form.password,
             };
 
-            await issueCertificate(certificate);
+            try {
+                await issueCertificate(certificate);
+            } catch (error) {
+                if (error.code !== 'CERTIFICATE_EXISTS') {
+                    throw error;
+                }
+
+                const shouldReplace = await confirmCertificateReplacement();
+                if (!shouldReplace) {
+                    dispatch({ type: ACTIONS.SET_LOADING, payload: false });
+                    return false;
+                }
+
+                await issueCertificate({ ...certificate, replaceExisting: true });
+            }
 
             dispatch({ type: ACTIONS.SET_LOADING, payload: false });
             Alert.alert('Success', 'Certificate emitted successfully.');

--- a/code/services/blockchain/certificates.js
+++ b/code/services/blockchain/certificates.js
@@ -18,6 +18,7 @@ export async function issueCertificate({
     grade,
     certificateReference,
     password,
+    replaceExisting = false,
 }) {
     try {
         const institution = getIssuingInstitution(issuerWallet);
@@ -34,6 +35,13 @@ export async function issueCertificate({
 
         const claimIssuerWallet = getWalletFromPrivateKey(institution.wallet.privateKey);
         await assertIssuerCanWriteCertificate(identity, institution, claimIssuerWallet.address);
+
+        if (!replaceExisting && await hasCertificateFromIssuer(identity, institution.address)) {
+            throw new BlockchainError(
+                'This institution has already issued a certificate for this student in the certificate topic.',
+                'CERTIFICATE_EXISTS'
+            );
+        }
 
         const operations = buildCertificateClaims({
             institution,
@@ -67,6 +75,16 @@ export async function issueCertificate({
         if (error instanceof BlockchainError) throw error;
         throw new BlockchainError(`Failed to issue certificate: ${error.message}`);
     }
+}
+
+async function hasCertificateFromIssuer(identity, issuerAddress) {
+    const topic = ethers.id(CLAIM_TOPICS_OBJ.CERTIFICATE);
+    const expectedClaimId = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'uint256'], [issuerAddress, topic])
+    );
+    const claimIds = await identity.getClaimIdsByTopic(topic);
+
+    return claimIds.some(claimId => claimId.toLowerCase() === expectedClaimId.toLowerCase());
 }
 
 export async function revokeCertificate({ issuerWallet, receiverWalletAddress, claimId = null }) {

--- a/code/services/ethereum/test/full-test-with-rpc.test.js
+++ b/code/services/ethereum/test/full-test-with-rpc.test.js
@@ -106,5 +106,33 @@ describe('End-to-end certificate flow', () => {
             certificateData
         );
 
+        const replacementReference = 'ipfs://certificate/2024/0001-corrected';
+        const replacementData = {
+            ...certificateData,
+            grade: '19',
+            certificateDigest: hash(replacementReference),
+        };
+
+        await addClaim(
+            trustedIssuersRegistry,
+            studentIdentity,
+            claimIssuerContract,
+            institutionWallet,
+            CLAIM_TOPICS_OBJ.CERTIFICATE,
+            JSON.stringify(replacementData),
+            1,
+            replacementReference
+        );
+
+        const updatedCertificateClaims = await getClaimsByTopic(
+            studentIdentity,
+            CLAIM_TOPICS_OBJ.CERTIFICATE
+        );
+        expect(updatedCertificateClaims).to.have.lengthOf(1);
+        expect(updatedCertificateClaims[0].id).to.equal(certificateClaims[0].id);
+        expect(updatedCertificateClaims[0].uri).to.equal(hash(replacementReference));
+        expect(JSON.parse(ethers.toUtf8String(updatedCertificateClaims[0].data))).to.deep.equal(
+            replacementData
+        );
     });
 });


### PR DESCRIPTION
## 📖 Summary

Adds a safety check before an institution replaces an existing certificate claim for the same student and topic.

## 🤔 What has been done?

- Detects when the issuer already has a certificate claim for the same student/topic.
- Returns a clear domain error unless replacement is explicitly requested.
- Adds a confirmation step in the certificate issuance flow before allowing the update.
- Covers the replacement behavior with an end-to-end blockchain test.

<!-- Explain any unchecked item. -->

## Evidence

- [x] `npm run test:blockchain`
- [x] `npx expo export --platform ios`
- [ ] Manual QA completed

## Review notes

**Depends on:** #11 

**Out of scope:**
- Changing the underlying smart contract update behavior
- Supporting multiple certificates from the same institution on the same topic
- Reown AppKit migration

## Checklist

- [x] The PR has one clear responsibility
- [x] No secrets, private keys, or local endpoints are committed
- [x] Documentation reflects user-facing or setup changes
- [x] Dead code and obsolete dependencies were not introduced